### PR TITLE
Feature/parse template

### DIFF
--- a/unload/base.py
+++ b/unload/base.py
@@ -67,15 +67,18 @@ class Template(BaseTemplate):
         """
         Get the list of tokens from the template source.
 
+        A modified version of Django's compile_nodelist method (Template class)
+        https://github.com/django/django/blob/master/django/template/base.py#L221
+
         :returns: a list of Tokens
         """
+        # From Django's source code
         if self.engine.debug:
             from django.template.debug import DebugLexer
-            lexer_class = DebugLexer
+            lexer = DebugLexer(self.source, self.origin)
         else:
-            lexer_class = Lexer
+            lexer = Lexer(self.source, self.origin)
 
-        lexer = lexer_class(self.source, self.origin)
         return lexer.tokenize()
 
     def _get_loaded_templatetags_modules(self):
@@ -114,8 +117,8 @@ class Template(BaseTemplate):
             token_content = token.split_contents()
             # Extract blocks that do not contain one of the built-in tags
             if token.token_type == 2 and\
-                    token_content[0] not in BUILT_IN_TAGS and\
-                    token_content[0] not in list(set(BUILT_IN_TAGS.values())):
+                    token_content[0] not in BUILT_IN_TAGS.keys() and\
+                    token_content[0] not in set(BUILT_IN_TAGS.values()):
                 # Extract only the name of the template tag (ignore arguments)
                 loaded_tags.append(token_content[0])
 

--- a/unload/base.py
+++ b/unload/base.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.template.base import Lexer, Template as BaseTemplate
+
+
+class Template(BaseTemplate):
+
+    def __init__(self, template_string, origin=None, name=None, engine=None):
+        super(Template, self).__init__(template_string, origin, name, engine)
+
+        # Used for backwards compatibility (implemented in Django 1.9)
+        if not hasattr(self, 'source'):
+            self.source = template_string
+
+        self.tokens = self._get_tokens()
+
+    def _get_tokens(self):
+        """
+        Get the list of tokens from the template source.
+
+        :returns: a list of Tokens
+        """
+        if self.engine.debug:
+            from django.template.debug import DebugLexer
+            lexer_class = DebugLexer
+        else:
+            lexer_class = Lexer
+
+        lexer = lexer_class(self.source, self.origin)
+        return lexer.tokenize()

--- a/unload/logic.py
+++ b/unload/logic.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.template.loader import get_template
+
+from .base import Template
+from .utils import open_template
+from .search import AppSearch, ProjectSearch
+
+
+def find_unused_tags(app=None):
+
+    app_search = None
+    project_search = None
+
+    if app:
+        app_search = AppSearch(app=app)
+    else:
+        project_search = ProjectSearch()
+
+    if project_search:
+        for template_path in project_search.project_templates:
+            process_template(template_path)
+            import ipdb; ipdb.set_trace()
+
+
+def process_template(filepath):
+    base_template = get_template(filepath)
+    engine = base_template.template.engine
+    source = open_template(filepath=filepath,
+                           encoding=engine.file_charset)
+
+    template = Template(template_string=source, engine=engine)

--- a/unload/logic.py
+++ b/unload/logic.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+from django.template.base import TemplateSyntaxError
 from django.template.loader import get_template
 
 from .base import Template
@@ -10,25 +11,45 @@ from .search import AppSearch, ProjectSearch
 
 
 def find_unused_tags(app=None):
-
+    """
+    To be changed in the near future!
+    """
     app_search = None
     project_search = None
 
     if app:
         app_search = AppSearch(app=app)
+        process_app_templates(app_search=app_search)
     else:
         project_search = ProjectSearch()
 
-    if project_search:
         for template_path in project_search.project_templates:
             process_template(template_path)
-            import ipdb; ipdb.set_trace()
+
+        for app_search in project_search.app_templates:
+            process_app_templates(app_search=app_search)
+
+
+def process_app_templates(app_search):
+    """
+    To be changed in the near future!
+    """
+    for template_path in app_search.templates:
+        process_template(template_path)
 
 
 def process_template(filepath):
-    base_template = get_template(filepath)
+    """
+    To be changed in the near future!
+    """
+    try:
+        base_template = get_template(filepath)
+    except TemplateSyntaxError as tse:
+        print filepath
+        return
+
     engine = base_template.template.engine
     source = open_template(filepath=filepath,
                            encoding=engine.file_charset)
 
-    template = Template(template_string=source, engine=engine)
+    template = Template(template_string=source, engine=engine, name=filepath)

--- a/unload/management/commands/find_unused_tags.py
+++ b/unload/management/commands/find_unused_tags.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from django.core.management.base import BaseCommand
 from django.utils.translation import ugettext_lazy as _
 
+from ...logic import find_unused_tags
 from ...search import ProjectSearch, AppSearch
 from ...utils import get_app
 
@@ -19,9 +20,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        app_name = options.get('app')
+        app_name = options.get('app', None)
         if app_name:
             app = get_app(app_name)
-            AppSearch(app=app)
         else:
-            ProjectSearch()
+            app = None
+
+        find_unused_tags(app=app)

--- a/unload/utils.py
+++ b/unload/utils.py
@@ -7,14 +7,15 @@ import io
 from django.apps import apps
 
 
-def get_app(app_name):
+def get_app(app_label):
     """
     Get the app object.
 
+    :app_label: the app's label submitted by the user
     :returns: AppConfig
     """
     try:
-        app = apps.get_app_config(app_name)
+        app = apps.get_app_config(app_label)
     except LookupError as le:
         raise le
 
@@ -25,7 +26,11 @@ def open_template(filepath, encoding='UTF-8'):
     """
     Read the contents of the template file.
 
+    A modified version of Django's get_contents method (Loader class)
+    https://github.com/django/django/blob/master/django/template/loaders/filesystem.py#L22
+
     :filepath: absolute path to the template file
+    :encoding: a string representing the engine's encoding
     :returns: contents of the template as a string
     """
     with io.open(filepath, encoding=encoding) as fp:

--- a/unload/utils.py
+++ b/unload/utils.py
@@ -2,14 +2,31 @@
 
 from __future__ import unicode_literals
 
+import io
+
 from django.apps import apps
 
 
 def get_app(app_name):
-    """Get the app object"""
+    """
+    Get the app object.
+
+    :returns: AppConfig
+    """
     try:
         app = apps.get_app_config(app_name)
     except LookupError as le:
         raise le
 
     return app
+
+
+def open_template(filepath, encoding='UTF-8'):
+    """
+    Read the contents of the template file.
+
+    :filepath: absolute path to the template file
+    :returns: contents of the template as a string
+    """
+    with io.open(filepath, encoding=encoding) as fp:
+        return fp.read()


### PR DESCRIPTION
The template files are parsed and the results (the names of the loaded modules and custom template tags) are added to the Template instances. Django's frameworks that supply template tags, such as _cache, static, l10n, i18n_, will be treated as custom template tags due to the fact that they can be loaded, but left unused. 

Please ignore _logic.py_ for the time being. At the moment it is used only for locating template files and testing the overridden Template class.
